### PR TITLE
Fixes

### DIFF
--- a/src/uwrap.cc
+++ b/src/uwrap.cc
@@ -161,7 +161,7 @@ namespace uwrap {
 			}
 		}
 
-		UWrap() {
+		UWrap() : asyncResource("uwrap:UWrap") {
 			handle = -1;
 		}
 
@@ -174,12 +174,12 @@ namespace uwrap {
 
 		void callback(string msg, v8::Local<v8::Value> a0) {
 			v8::Local<v8::Value> argv[2] { Nan::New(msg.c_str()).ToLocalChecked(),  a0 };
-			Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(jscallback), 2, argv);
+			asyncResource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(jscallback), 2, argv);
 		}
 
 		void callback(string msg, v8::Local<v8::Value> a0, v8::Local<v8::Value> a1) {
 			v8::Local<v8::Value> argv[3] { Nan::New(msg.c_str()).ToLocalChecked(),  a0, a1 };
-			Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(jscallback), 3, argv);
+			asyncResource.runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(jscallback), 3, argv);
 		}
 
 		static void poll_thunk(uv_poll_t *handle, int status, int events) {
@@ -253,9 +253,11 @@ namespace uwrap {
 		}
 
 		int handle;
-		Nan::Persistent<v8::Function> jscallback;
 		uv_poll_t uvpoll;
 		bool paused;
+
+		Nan::AsyncResource asyncResource;
+		Nan::Persistent<v8::Function> jscallback;
 	};
 
 

--- a/src/uwrap.cc
+++ b/src/uwrap.cc
@@ -166,8 +166,10 @@ namespace uwrap {
 		}
 
 		~UWrap() {
-			if (handle != -1)
+			if (handle != -1) {
+				uv_close(reinterpret_cast<uv_handle_t*>(&uvpoll), nullptr);
 				::close(handle);
+			}
 		}
 
 		void callback(string msg, v8::Local<v8::Value> a0) {
@@ -229,6 +231,7 @@ namespace uwrap {
 			jscallback.Reset();
 			if (handle != -1) {
 				uv_poll_stop(&uvpoll);
+				uv_close(reinterpret_cast<uv_handle_t*>(&uvpoll), nullptr);
 				::close(handle);
 				handle = -1;
 			}


### PR DESCRIPTION
Hi,

I'd like to fix some issues with usocket:

* not closing uvpoll causing crashes of node, as libuv loop tried to clean up not closed handles, but UWrap could be deleted by that time
* propagating errors from uv_poll_start, uv_poll_stop to JS
* deprecated MakeCallback in node 10

Could you look at it?
Thanks.