### PR TITLE
bump node-gyp to 8.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   "dependencies": {
     "bindings": "^1.5.0",
     "nan": "^2.14.2",
-    "node-gyp": "^7.1.2"
+    "node-gyp": "^8.2.0"
   }
 }


### PR DESCRIPTION
7.1.* still uses deprecated `request` module