### PR TITLE
Fix for util.isError removed in Node 23+

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,8 @@ USocket.prototype._write = function(chunk, encoding, callback) {
 
 	debug("USocket._write", data && data.length, fds);
 	var r = this._wrap.write(data, fds);
-	if (util.isError(r)) {
+	var isError = Error.isError ? Error.isError(r) : util.types.isNativeError(value);
+	if (isError) {
 		debug("USocket._write error", r);
 		return callback(r);
 	}


### PR DESCRIPTION
In Node 23+, util.isError has been removed completely (has been deprecated for a long while prior to that). 
See: https://nodejs.org/api/deprecations.html#DEP0048
This of course causes `Error handler TypeError: util.isError is not a function` 

Originally the recommendation was to use `util.types.isNativeError(value)` instead - however since Node 24.2 that one is also considered deprecated, so the current recommendation is `Error.isError()` which was added in the same version.
See: https://nodejs.org/docs/latest-v25.x/api/util.html#utiltypesisnativeerrorvalue

Given that Node v20.x will soon lose its maintenence status, it would be great to get it fixed, so I tried the obvious - switching it locally to `Error.isError` - which seemed to fix the issue so here's the MR. 

**Edit:** For backwards compatibility with versions older than Node 24.2 (but also for the ones newer than Node v22.0, I kept the `util.types.isNativeError` present for environments where `Error.isError` is not yet available.